### PR TITLE
Introduce better handling of elements transformation

### DIFF
--- a/src/shape/Node.coffee
+++ b/src/shape/Node.coffee
@@ -27,13 +27,9 @@ export slope = 20
 
 export togglerSize = 10 
 export togglerButtonShape = basegl.expr ->
-    isFolded = 'isFolded'
     triangle(togglerSize, togglerSize)
         .fill white
-        .rotate(isFolded * Math.PI)
-        .moveX togglerSize/2
-        .moveY(isFolded * togglerSize)
-        
+        .moveX togglerSize/2        
 
 basicNodeShape = -> basegl.expr ->
     border = 0

--- a/src/view/Component.coffee
+++ b/src/view/Component.coffee
@@ -47,11 +47,13 @@ export class Component extends PropertyEmitter
         if @def?
             if @def instanceof Array
                 @view = {}
-                views = []
+                @groups = {}
+                groups  = []
                 for def in @def
                     @view[def.name] = scene.add def.def
-                    views.push @view[def.name]
-                @group = group views
+                    @groups[def.name] = group [@view[def.name]]
+                    groups.push @groups[def.name]
+                @group = group groups
             else
                 @view = scene.add @def
                 @group = group [@view]

--- a/src/view/Component.coffee
+++ b/src/view/Component.coffee
@@ -46,16 +46,17 @@ export class Component extends PropertyEmitter
     attach: => @withScene (scene) =>
         if @def?
             if @def instanceof Array
+                @element = {}
                 @view = {}
-                @groups = {}
-                groups  = []
+                views  = []
                 for def in @def
-                    @view[def.name] = scene.add def.def
-                    @groups[def.name] = group [@view[def.name]]
-                    groups.push @groups[def.name]
-                @group = group groups
+                    @element[def.name] = scene.add def.def
+                    @view[def.name] = group [@element[def.name]]
+                    views.push @view[def.name]
+                @group = group views
             else
-                @view = scene.add @def
+                @element = scene.add @def
+                @view  = @element
                 @group = group [@view]
             @updateView()
         @registerEvents?()

--- a/src/view/Connection.coffee
+++ b/src/view/Connection.coffee
@@ -61,22 +61,22 @@ export class Connection extends Component
         rotation = Math.atan2 y, x
         @view.src.position.x = leftOffset
         @view.src.position.y = -shape.width/2
-        @view.src.bbox.x = length/2
+        @element.src.bbox.x = length/2
         @view.dst.position.x = leftOffset + length/2
         @view.dst.position.y = -shape.width/2
-        @view.dst.bbox.x = length/2
+        @element.dst.bbox.x = length/2
         @group.position.xy = [srcPos[0], srcPos[1]]
         @view.src.rotation.z = rotation
         @view.dst.rotation.z = rotation
         srcPort.follow @key, rotation - Math.PI/2
         dstPort.follow @key, rotation + Math.PI/2
 
-        @view.src.variables.color_r = srcPort.color[0]
-        @view.src.variables.color_g = srcPort.color[1]
-        @view.src.variables.color_b = srcPort.color[2]
-        @view.dst.variables.color_r = srcPort.color[0]
-        @view.dst.variables.color_g = srcPort.color[1]
-        @view.dst.variables.color_b = srcPort.color[2]
+        @element.src.variables.color_r = srcPort.color[0]
+        @element.src.variables.color_g = srcPort.color[1]
+        @element.src.variables.color_b = srcPort.color[2]
+        @element.dst.variables.color_r = srcPort.color[0]
+        @element.dst.variables.color_g = srcPort.color[1]
+        @element.dst.variables.color_b = srcPort.color[2]
 
     connectSources: (srcPort, dstPort) =>
         unless @srcConnected

--- a/src/view/ExpressionNode.coffee
+++ b/src/view/ExpressionNode.coffee
@@ -100,7 +100,7 @@ export class ExpressionNode extends Component
         if selected != @selected
             @selected = selected
             if @view?
-                applySelectAnimation @view.node, not @selected
+                applySelectAnimation @element.node, not @selected
         @widgets ?= {}
         @setInPorts inPorts
         @setOutPorts outPorts
@@ -184,32 +184,32 @@ export class ExpressionNode extends Component
         valueSize     = [0,0]
         valuePosition = @view.node.position
         if @view.value?
-            valueSize = util.textSize @view.value
+            valueSize = util.textSize @element.value
             @view.value.position.y = @view.node.position.y - valueSize[1]/2
             unless @expanded
                 @view.value.position.x = -valueSize[0]/2
             valuePosition = @view.value.position
 
-        @view.valueToggler.position.x = -shape.togglerSize/2
+        @element.valueToggler.position.x = -shape.togglerSize/2
         if @value?.contents?.tag == 'Visualization'
-            @view.valueToggler.rotation.z = 0
+            @element.valueToggler.rotation.z = 0
         else
-            @view.valueToggler.rotation.z = Math.PI
-            @view.valueToggler.position.y = -shape.togglerSize
+            @element.valueToggler.rotation.z = Math.PI
+            @element.valueToggler.position.y = -shape.togglerSize
 
-        @groups.valueToggler.position.y =
+        @view.valueToggler.position.y =
             @view.node.position.y - valueSize[1] - shape.togglerSize
-        
+
     updateView: =>
         if @expanded
-            @view.node.variables.bodyHeight = @bodyHeight
-            @view.node.variables.bodyWidth  = @bodyWidth
+            @element.node.variables.bodyHeight = @bodyHeight
+            @element.node.variables.bodyWidth  = @bodyWidth
             nodePosition = [-shape.width/2, -@bodyHeight - shape.height/2 - shape.slope]
-            @view.node.position.xy = nodePosition
+            @element.node.position.xy = nodePosition
             if @error()
-                @view.errorFrame.variables.bodyHeight = @bodyHeight
-                @view.errorFrame.variables.bodyWidth  = @bodyWidth
-                @view.errorFrame.position.xy = nodePosition
+                @element.errorFrame.variables.bodyHeight = @bodyHeight
+                @element.errorFrame.variables.bodyWidth  = @bodyWidth
+                @element.errorFrame.position.xy = nodePosition
             for own inPortKey, inPort of @inPorts
                 widgets = @widgets[inPortKey]
                 if widgets?
@@ -222,12 +222,12 @@ export class ExpressionNode extends Component
             if @error()
                 @view.errorFrame.position.xy = [-shape.width/2, -shape.height/2]
         @updateValueView()
-        nameSize = util.textSize @view.name
-        exprWidth = util.textWidth @view.expression
+        nameSize = util.textSize @element.name
+        exprWidth = util.textWidth @element.expression
         @view.name.position.xy = [-nameSize[0]/2, nodeNameYOffset + nameSize[1]]
         @view.expression.position.xy = [-exprWidth/2, nodeExprYOffset]
         @group.position.xy = @position.slice()
-        @view.node.variables.selected = if @selected then 1 else 0
+        @element.node.variables.selected = if @selected then 1 else 0
 
     updateInPorts: =>
         @selfPort = undefined

--- a/src/view/ExpressionNode.coffee
+++ b/src/view/ExpressionNode.coffee
@@ -191,12 +191,14 @@ export class ExpressionNode extends Component
             valuePosition = @view.value.position
 
         @view.valueToggler.position.x = -shape.togglerSize/2
-        @view.valueToggler.position.y =
-            @view.node.position.y - valueSize[1] - shape.togglerSize/2
         if @value?.contents?.tag == 'Visualization'
-            @view.valueToggler.variables.isFolded = 0.0
+            @view.valueToggler.rotation.z = 0
         else
-            @view.valueToggler.variables.isFolded = 1.0
+            @view.valueToggler.rotation.z = Math.PI
+            @view.valueToggler.position.y = -shape.togglerSize
+
+        @groups.valueToggler.position.y =
+            @view.node.position.y - valueSize[1] - shape.togglerSize
         
     updateView: =>
         if @expanded

--- a/src/view/Port.coffee
+++ b/src/view/Port.coffee
@@ -142,15 +142,15 @@ class InArrow extends Port
                 [@parent.position[0] + shape.length, @parent.position[1]]
             else
                 @parent.position
-        @view.port.position.xy = [-shape.width/2, @parent.radius]
-        @view.port.variables.color_r = @parent.color[0]
-        @view.port.variables.color_g = @parent.color[1]
-        @view.port.variables.color_b = @parent.color[2]
+        @element.port.position.xy = [-shape.width/2, @parent.radius]
+        @element.port.variables.color_r = @parent.color[0]
+        @element.port.variables.color_g = @parent.color[1]
+        @element.port.variables.color_b = @parent.color[2]
         rotation = @angle
-        @view.port.rotation.z = rotation
-        nameSize = util.textSize @view.name
-        @view.name.rotation.z = rotation - Math.PI/2
-        @view.name.position.xy = [- nameSize[0] - nameOffset - shape.length - @radius, -nameSize[1]/2]
+        @element.port.rotation.z = rotation
+        nameSize = util.textSize @element.name
+        @element.name.rotation.z = rotation - Math.PI/2
+        @element.name.position.xy = [- nameSize[0] - nameOffset - shape.length - @radius, -nameSize[1]/2]
 
 
 outPortShape = basegl.symbol shape.outPortShape
@@ -208,8 +208,8 @@ export class FlatPort extends Subports
     updateView: =>
         x = if @output then @position[0] else @position[0] - shape.length
         @group.position.xy = [x, @position[1] - shape.width/2]
-        nameHeight = util.textHeight @view.name
+        nameHeight = util.textHeight @element.name
         @view.name.position.xy = [2* shape.length, nameHeight/2]
-        @view.port.variables.color_r = @color[0]
-        @view.port.variables.color_g = @color[1]
-        @view.port.variables.color_b = @color[2]
+        @element.port.variables.color_r = @color[0]
+        @element.port.variables.color_g = @color[1]
+        @element.port.variables.color_b = @color[2]

--- a/src/view/Slider.coffee
+++ b/src/view/Slider.coffee
@@ -46,13 +46,13 @@ export class Slider extends Widget
                , {name: 'value',  def: valueShape} ]
 
     updateView: =>
-        @view.slider.variables.level = (@value - @min)/(@max - @min)
-        @view.slider.variables.topLeft     = Number not (@siblings.top or @siblings.left)
-        @view.slider.variables.topRight    = Number not (@siblings.top or @siblings.right)
-        @view.slider.variables.bottomLeft  = Number not (@siblings.bottom or @siblings.left)
-        @view.slider.variables.bottomRight = Number not (@siblings.bottom or @siblings.right)
-        @view.slider.bbox.xy = [@width, @height]
-        textSize = util.textSize @view.value
+        @element.slider.variables.level = (@value - @min)/(@max - @min)
+        @element.slider.variables.topLeft     = Number not (@siblings.top or @siblings.left)
+        @element.slider.variables.topRight    = Number not (@siblings.top or @siblings.right)
+        @element.slider.variables.bottomLeft  = Number not (@siblings.bottom or @siblings.left)
+        @element.slider.variables.bottomRight = Number not (@siblings.bottom or @siblings.right)
+        @element.slider.bbox.xy = [@width, @height]
+        textSize = util.textSize @element.value
         @view.value.position.xy = [@width/2 - textSize[0]/2 , @height/2 - textSize[1]/2]
         @group.position.xy = [@position[0], @position[1] - @height/2]
 


### PR DESCRIPTION
There was a slight inconsequence with groups logic. If we have `@def` made of multiple elements we create map `@view` for every handler given by `scene.add`, but we handle only one group - `@group = group [all @view elements]`. This disallows us to do such convenient things as we can do with the single object in @def (`@def = {}`, not `@def=[]`). In the second case, we can modify element by modifications on `@view` and then just position it correctly using `@group`.

This pr resolves problems like this one: we have a toggler with the defined shape which is part of node. So naturally `@view.valueToggler = scene.add toggler` and `@group = group [.., @view.valueToggler]`. This means that if we want to transform all node components we use `@group`, if just toggler `@view.valueToggler`. This means that we need to position toggler inside of `@group` using `@view.valueToggler`. But we need to rotate our toggler shape if visualization is folded - if we just apply rotation it will be applied with the center in `@group` center which ends up with toggler displayed above the node instead of below.

With this pr we introduce `@element` which is renamed previous `@view` and introduce new meaning of `@view`. Renaming seems important to catch the idea here. If our symbol requires some transformations itself we use `@element` (for example to center your shape), `@view` is used for transformations which should transform `@element` in context of the group it's in. Finally, `@group` meaning stays unchanged.

This PR contains two commits - first one is minimal changed to show how this is really a design fix rather than enhancement 