### PR TITLE
Make scene with an independent camera for dom elements

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "webpack": "^3.9.1"
   },
   "dependencies": {
-    "basegl": "0.2.13",
+    "basegl": "0.2.15",
     "bluebird": "^3.5.1",
     "glslify-loader": "^1.0.2",
     "raw-loader": "^0.5.1",

--- a/src/view/NodeEditor.coffee
+++ b/src/view/NodeEditor.coffee
@@ -27,8 +27,11 @@ export class NodeEditor extends EventEmitter
         @pending              = []
         @topDomScene          = @_scene.addDOMScene()
         topDomLayer           = @_scene.addLayer 'dom-top'
-        topDomLayer.style.pointerEvents = 'none'
         topDomLayer.appendChild @topDomScene.renderer.domElement
+        @topDomSceneNoScale   = @_scene.addDOMSceneWithNewCamera()
+        topDomLayerNoScale    = @_scene.addLayer 'dom-top-no-scale'
+        topDomLayerNoScale.appendChild @topDomSceneNoScale.renderer.domElement
+
         visCoverFamily = @_scene.register visualizationCover
         visCoverFamily.zIndex = -1
 


### PR DESCRIPTION
With this PR we introduce another layer on top. This layer and scene are for dom elements that shouldn't be dependent on camera contexts - like searcher or full-screen visualization.