### PR TITLE
Align the searcher with the node's expression

### DIFF
--- a/dist/style/_searcher.less
+++ b/dist/style/_searcher.less
@@ -34,6 +34,11 @@
     position: absolute;
 }
 
+.luna-searcher__root {
+    width:  0;
+    height: 0;
+}
+
 .luna-searcher__body {
     width: 0;
 }

--- a/src/main.coffee
+++ b/src/main.coffee
@@ -90,7 +90,11 @@ runExample = -> main (nodeEditor) ->
             position: [200, 600]
             expanded: false
             selected: false
-            value: '54'
+            value:
+                tag: 'Value'
+                contents:
+                    tag: 'ShortValue'
+                    contents: 'A sample text'
         new ExpressionNode
             key: 3
             name: 'baz'

--- a/src/main.coffee
+++ b/src/main.coffee
@@ -108,8 +108,7 @@ runExample = -> main (nodeEditor) ->
             value:
                 tag: 'Value'
                 contents:
-                    tag: 'ShortValue'
-                    contents: 'A sample text'
+                    tag: 'Visualization'
         new ExpressionNode
             key: 3
             name: 'baz'

--- a/src/view/ExpressionNode.coffee
+++ b/src/view/ExpressionNode.coffee
@@ -52,8 +52,9 @@ compactNodeErrorShape.defaultZIndex = layers.compactNodeError
 compactNodeErrorShape.variables.selected = 0
 compactNodeErrorShape.bbox.xy = [shape.errorWidth, shape.errorHeight]
 
-nodeNameYOffset = shape.width / 3 + 5
-nodeExprYOffset = shape.width / 3
+nodeExprYOffset = shape.height / 3
+nodeNameYOffset = nodeExprYOffset + 5
+nodeValYOffset  = -nodeNameYOffset
 
 portDistance = shape.height / 3
 
@@ -198,7 +199,7 @@ export class ExpressionNode extends Component
                 @view.errorFrame.position.xy = [-shape.width/2, -shape.height/2]
             if @shortValue()?
                 errorSize = util.textSize @view.value
-                @view.value.position.xy = [- errorSize[0]/2, -shape.height/2 - errorSize[1]/2]
+                @view.value.position.xy = [- errorSize[0]/2, nodeValYOffset - errorSize[1]/2]
         nameSize = util.textSize @view.name
         exprWidth = util.textWidth @view.expression
         @view.name.position.xy = [-nameSize[0]/2, nodeNameYOffset + nameSize[1]]

--- a/src/view/Searcher.coffee
+++ b/src/view/Searcher.coffee
@@ -5,7 +5,7 @@ import * as shape  from 'shape/Node'
 
 
 searcherRoot    = 'searcher-root'
-searcherWidth   = 400  # this sadly needs to be in sync with `_searcher.less`
+searcherWidth   = 400  # same as `@searcherWidth` in `_searcher.less`
 
 
 export class Searcher extends Component
@@ -23,8 +23,7 @@ export class Searcher extends Component
         unless @def?
             root = document.createElement 'div'
             root.id = searcherRoot
-            root.style.width  = 0
-            root.style.height = 0
+            root.className = style.luna ['searcher__root']
             @def = basegl.symbol root
 
     updateView: =>
@@ -107,17 +106,17 @@ export class Searcher extends Component
             @inputSelection = null
         return @dom.input
 
+    offsetFromNode: => [-searcherWidth / 8 * @scale, shape.height / 8 * @scale]
+
     align: (scale) =>
         if @scale != scale
             @scale = scale
-            console.log("Scale: #{@scale}")
             node = @parent.node @key
             if node?
                 [posx, posy] = node.position.slice()
-                exprPosY = node.view.expression.position.y
-                offsetX  = - searcherWidth / 8 * @scale
-                offsetY  = exprPosY + shape.height / 8 * @scale
-                @group.position.xy = [posx + offsetX, posy + offsetY]
+                exprPosY     = node.view.expression.position.y
+                [offX, offY] = @offsetFromNode()
+                @group.position.xy = [offX + posx, offY + exprPosY + posy]
                 @view.scale.xy     = [@scale, @scale]
 
     registerEvents: =>

--- a/src/view/Searcher.coffee
+++ b/src/view/Searcher.coffee
@@ -6,7 +6,8 @@ import * as shape  from 'shape/Node'
 
 searcherRoot    = 'searcher-root'
 searcherWidth   = 400  # same as `@searcherWidth` in `_searcher.less`
-
+searcherBaseOffsetX = -searcherWidth / 8
+searcherBaseOffsetY = shape.height   / 8
 
 export class Searcher extends Component
     cons: (args...) =>
@@ -106,7 +107,7 @@ export class Searcher extends Component
             @inputSelection = null
         return @dom.input
 
-    offsetFromNode: => [-searcherWidth / 8 * @scale, shape.height / 8 * @scale]
+    offsetFromNode: => [searcherBaseOffsetX * @scale, searcherBaseOffsetY * @scale]
 
     align: (scale) =>
         if @scale != scale

--- a/src/view/Searcher.coffee
+++ b/src/view/Searcher.coffee
@@ -1,9 +1,12 @@
 import {Component} from 'view/Component'
 import * as basegl from 'basegl'
 import * as style  from 'style'
+import * as shape  from 'shape/Node'
 
 
-searcherRoot = 'searcher-root'
+searcherRoot    = 'searcher-root'
+searcherWidth   = 400  # this sadly needs to be in sync with `_searcher.less`
+
 
 export class Searcher extends Component
     cons: (args...) =>
@@ -20,9 +23,8 @@ export class Searcher extends Component
         unless @def?
             root = document.createElement 'div'
             root.id = searcherRoot
-            root.style.width = 100 + 'px'
-            root.style.height = 150 + 'px'
-            # root.style.backgroundColor = '#FF0000'
+            root.style.width  = 0
+            root.style.height = 0
             @def = basegl.symbol root
 
     updateView: =>
@@ -108,10 +110,15 @@ export class Searcher extends Component
     align: (scale) =>
         if @scale != scale
             @scale = scale
+            console.log("Scale: #{@scale}")
             node = @parent.node @key
             if node?
-                @group.position.xy = node.position.slice()
-                @view.scale.xy = [@scale, @scale]
+                [posx, posy] = node.position.slice()
+                exprPosY = node.view.expression.position.y
+                offsetX  = - searcherWidth / 8 * @scale
+                offsetY  = exprPosY + shape.height / 8 * @scale
+                @group.position.xy = [posx + offsetX, posy + offsetY]
+                @view.scale.xy     = [@scale, @scale]
 
     registerEvents: =>
         @withScene (scene) =>


### PR DESCRIPTION
This is not the change the searcher deserves, but the change it needs. If you know of a better way of keeping the node's expression and searcher's input aligned at all times, please let me know, I'm learning here. 

For now I think it works -- it even zooms correctly (quite unlike the old gui, where this particular aspect was not taken care of).