### PR TITLE
Node Searcher using the new component model

### DIFF
--- a/src/abstract/BasicComponent.coffee
+++ b/src/abstract/BasicComponent.coffee
@@ -32,6 +32,10 @@ export class BasicComponent extends HasModel
             @__view = null
         super()
 
+    getElement: => @__element
+
+    getDomElement: => @getElement()?.domElement
+
     # # implement following methods when deriving: #
     # ##############################################
     #

--- a/src/abstract/HasModel.coffee
+++ b/src/abstract/HasModel.coffee
@@ -58,3 +58,5 @@ export class HasModel extends EventEmitter
     __removeFromGroup: (view) =>
         @__view.removeChild view
         @__view.updateChildrenOrigin()
+
+    warn: (msg) => console.warn "[#{@constructor.name}] #{msg}"

--- a/src/main.coffee
+++ b/src/main.coffee
@@ -273,8 +273,6 @@ runExample = -> main (nodeEditor) ->
         ]
     nodeEditor.setSearcher
         key: 4
-        mode: 'node'
-        selected: 0
         entries: [
             name: 'bar'
             doc:  'bar description'
@@ -288,6 +286,7 @@ runExample = -> main (nodeEditor) ->
             name: 'foo'
             doc:  'foo multiline\ndescription'
             className: 'Foo'
+            highlights: []
         ,
             name: 'baz'
             doc:  'baz description'

--- a/src/shape/Connection.coffee
+++ b/src/shape/Connection.coffee
@@ -52,5 +52,6 @@ export class ConnectionShape extends BasicComponent
             element.variables.color_b = @model.color[2]
 
     registerEvents: (view) =>
-        view.addEventListener 'mouseover', => @__element.variables.hovered = 1
-        view.addEventListener 'mouseout',  => @__element.variables.hovered = 0
+        vars = @getElement().variables
+        view.addEventListener 'mouseover', => vars.hovered = 1
+        view.addEventListener 'mouseout',  => vars.hovered = 0

--- a/src/shape/Html.coffee
+++ b/src/shape/Html.coffee
@@ -9,6 +9,7 @@ export class HtmlShape extends BasicComponent
         element: 'div'
         top: true
         scalable: true
+        still: false
 
     redefineRequired: =>
         @changed.id or @changed.element
@@ -20,10 +21,12 @@ export class HtmlShape extends BasicComponent
 
     adjust: =>
         if @changed.top or @changed.scalable
-            if @model.top and @model.scalable
-                @root.topDomScene.model.add @__element.obj
-            else if @model.top
+            if @model.still
+                @root.topDomSceneStill.add @__element.obj
+            else if not @model.scalable
                 @root.topDomSceneNoScale.model.add @__element.obj
+            else if @model.top
+                @root.topDomScene.model.add @__element.obj
                 @__forceUpdatePosition()
             else
                 @root.scene.domModel.model.add @view.obj
@@ -36,3 +39,10 @@ export class HtmlShape extends BasicComponent
                 @__element.position.y = 1
             else
                 @__element.position.y = 0
+
+    appendChild: (childElem) =>
+        unless @__element?
+            console.warn "[HtmlShape] Trying to appendChild to an uninitialized component."
+            return
+
+        @__element.domElement.appendChild childElem

--- a/src/shape/Html.coffee
+++ b/src/shape/Html.coffee
@@ -21,30 +21,20 @@ export class HtmlShape extends BasicComponent
 
     adjust: =>
         if @changed.top or @changed.scalable
+            obj = @getElement().obj
             if @model.still
-                @root.topDomSceneStill.add @__element.obj
+                @root.topDomSceneStill.add obj
             else if not @model.scalable
-                @root.topDomSceneNoScale.model.add @__element.obj
+                @root.topDomSceneNoScale.model.add obj
             else if @model.top
-                @root.topDomScene.model.add @__element.obj
+                @root.topDomScene.model.add obj
                 @__forceUpdatePosition()
             else
                 @root.scene.domModel.model.add @view.obj
 
-    getElement: => @__element
-
     # FIXME: This function is needed due to bug in basegl or THREE.js
     # which causes problems with positioning when layer changed
     __forceUpdatePosition: =>
-        if @__element?
-            if @__element.position.y == 0
-                @__element.position.y = 1
-            else
-                @__element.position.y = 0
-
-    appendChild: (childElem) =>
-        unless @__element?
-            @warn "Trying to appendChild to an uninitialized component."
-            return
-
-        @__element.domElement.appendChild childElem
+        if @getElement()?
+            elem = @getElement()
+            elem.position.y = if elem.position.y == 0 then 1 else 0

--- a/src/shape/Html.coffee
+++ b/src/shape/Html.coffee
@@ -31,6 +31,8 @@ export class HtmlShape extends BasicComponent
             else
                 @root.scene.domModel.model.add @view.obj
 
+    getElement: => @__element
+
     # FIXME: This function is needed due to bug in basegl or THREE.js
     # which causes problems with positioning when layer changed
     __forceUpdatePosition: =>
@@ -42,7 +44,7 @@ export class HtmlShape extends BasicComponent
 
     appendChild: (childElem) =>
         unless @__element?
-            console.warn "[HtmlShape] Trying to appendChild to an uninitialized component."
+            @warn "Trying to appendChild to an uninitialized component."
             return
 
         @__element.domElement.appendChild childElem

--- a/src/shape/port/Base.coffee
+++ b/src/shape/port/Base.coffee
@@ -18,5 +18,5 @@ export class PortShape extends BasicComponent
             element.variables.color_b = @model.color[2]
 
     registerEvents: (view) =>
-        view.addEventListener 'mouseover', => @__element.variables.hovered = 1
-        view.addEventListener 'mouseout',  => @__element.variables.hovered = 0
+        view.addEventListener 'mouseover', => @getElement().variables.hovered = 1
+        view.addEventListener 'mouseout',  => @getElement().variables.hovered = 0

--- a/src/shape/widget/Checkbox.coffee
+++ b/src/shape/widget/Checkbox.coffee
@@ -51,6 +51,6 @@ export class CheckboxShape extends BasicComponent
 
     adjust: (view, element) =>
         if @changed.checked
-            applyCheckAnimation @__element, not @model.checked
+            applyCheckAnimation @getElement(), not @model.checked
         if @changed.width or @changed.height
-            @__element.bbox.xy = [@model.width, @model.height]
+            @getElement().bbox.xy = [@model.width, @model.height]

--- a/src/shape/widget/Slider.coffee
+++ b/src/shape/widget/Slider.coffee
@@ -45,10 +45,11 @@ export class SliderShape extends BasicComponent
     define: => sliderSymbol
 
     adjust: (view) =>
-        if @changed.level       then @__element.variables.level       = Number @model.level
-        if @changed.topLeft     then @__element.variables.topLeft     = Number @model.topLeft
-        if @changed.topRight    then @__element.variables.topRight    = Number @model.topRight
-        if @changed.bottomLeft  then @__element.variables.bottomLeft  = Number @model.bottomLeft
-        if @changed.bottomRight then @__element.variables.bottomRight = Number @model.bottomRight
+        vars = @getElement().variables
+        if @changed.level       then vars.level       = Number @model.level
+        if @changed.topLeft     then vars.topLeft     = Number @model.topLeft
+        if @changed.topRight    then vars.topRight    = Number @model.topRight
+        if @changed.bottomLeft  then vars.bottomLeft  = Number @model.bottomLeft
+        if @changed.bottomRight then vars.bottomRight = Number @model.bottomRight
         if @changed.width or @changed.height
-            @__element.bbox.xy = [@model.width, @model.height]
+            @getElement().bbox.xy = [@model.width, @model.height]

--- a/src/view/Breadcrumb.coffee
+++ b/src/view/Breadcrumb.coffee
@@ -20,7 +20,8 @@ export class Breadcrumb extends ContainerComponent
 
     update: =>
         if @changed.once or @changed.items or @changed.moduleName
-            @def('root').__element.domElement.innerHTML = ''
+            domElem = @def('root').getDomElement()
+            domElem.innerHTML = ''
             container = document.createElement 'div'
             container.className = style.luna ['breadcrumbs', 'noselect']
             @model.items[0] =
@@ -28,7 +29,7 @@ export class Breadcrumb extends ContainerComponent
                 link: @model.moduleName?
             @model.items.forEach (item) =>
                 container.appendChild @__renderItem item
-            @def('root').__element.domElement.appendChild container
+            domElem.appendChild container
 
     adjust: (view) =>
         if @changed.once

--- a/src/view/NodeEditor.coffee
+++ b/src/view/NodeEditor.coffee
@@ -1,4 +1,5 @@
 import {Navigator}          from 'basegl/navigation/Navigator'
+import {ZoomlessCamera}     from 'basegl/navigation/Camera'
 
 import {Breadcrumb}         from 'view/Breadcrumb'
 import {Connection}         from 'view/Connection'
@@ -24,9 +25,12 @@ export class NodeEditor extends EventEmitter
         @visualizerLibraries ?= {}
         @inTransaction        = false
         @pending              = []
-        @topDomScene = @_scene.addDomModel('dom-top')
+        @topDomScene          = @_scene.addDomModel('dom-top')
         @topDomScene._renderer.domElement.style.pointerEvents='all'
-        @topDomSceneNoScale = @_scene.addDomModelWithNewCamera('dom-top-no-scale')
+        @topDomSceneStill     = @_scene.addDomModelWithNewCamera('dom-top-still')
+        @topDomSceneNoScale   =
+            @_scene.addDomModelWithNewCamera('dom-top-no-scale', new ZoomlessCamera @_scene._camera)
+
         visCoverFamily = @_scene.register visualizationCover
         visCoverFamily.zIndex = -1
 

--- a/src/view/NodeEditor.coffee
+++ b/src/view/NodeEditor.coffee
@@ -26,10 +26,12 @@ export class NodeEditor extends EventEmitter
         @inTransaction        = false
         @pending              = []
         @topDomScene          = @_scene.addDomModel('dom-top')
-        @topDomScene._renderer.domElement.style.pointerEvents='all'
         @topDomSceneStill     = @_scene.addDomModelWithNewCamera('dom-top-still')
         @topDomSceneNoScale   =
             @_scene.addDomModelWithNewCamera('dom-top-no-scale', new ZoomlessCamera @_scene._camera)
+        @topDomScene._renderer.domElement.style.pointerEvents='all'
+        @topDomSceneStill._renderer.domElement.style.pointerEvents='all'
+        @topDomSceneNoScale._renderer.domElement.style.pointerEvents='all'
 
         visCoverFamily = @_scene.register visualizationCover
         visCoverFamily.zIndex = -1

--- a/src/view/Searcher.coffee
+++ b/src/view/Searcher.coffee
@@ -54,7 +54,7 @@ export class Searcher extends ContainerComponent
         @dom.container.className = 'native-key-bindings ' + style.luna ['input', 'searcher', 'searcher--node']
         @dom.container.appendChild @dom.results
         @dom.container.appendChild @dom.input
-        @def('root').appendChild @dom.container
+        @def('root').getDomElement().appendChild @dom.container
 
     __createResults: =>
         @dom.results = document.createElement 'div'
@@ -70,7 +70,7 @@ export class Searcher extends ContainerComponent
 
     __updateResults: =>
         @dom.resultsList.innerText = ''
-        omit = if @model.selected == 0 then 0 else @model.selected - 1
+        omit = Math.max(0, @model.selected - 1)
         i = omit + 1
         @model.entries.slice(omit).forEach (entry) =>
             @dom.resultsList.appendChild @__renderResult entry, i == @model.selected
@@ -150,7 +150,7 @@ export class Searcher extends ContainerComponent
     __offsetFromNode: => [searcherBaseOffsetX, searcherBaseOffsetY]
 
     __onPositionChanged: (parentNode) =>
-        @set { position: parentNode.model.position }
+        @set position: parentNode.model.position
 
     ###################################
     ### Register the event handlers ###

--- a/src/view/Searcher.coffee
+++ b/src/view/Searcher.coffee
@@ -27,7 +27,7 @@ export class Searcher extends ContainerComponent
         position: [0, 0]
 
     prepare: =>
-        @dom ?= {}
+        @dom = {}
         @addDef 'root', new HtmlShape
                 element: 'div'
                 id: 'searcher-root'
@@ -132,10 +132,10 @@ export class Searcher extends ContainerComponent
     #######################
 
     adjust: (view) =>
-        if @changed.position or @changed.scale
+        if @changed.position
             @__withParentNode (parentNode) =>
-                [posx, posy] = parentNode.model.position.slice()
-                exprPosY     = parentNode.view('expression').position.y
+                [posx, posy] = @model.position.slice()
+                exprPosY = parentNode.view('expression').position.y
                 view.position.xy = [searcherBaseOffsetX + posx, searcherBaseOffsetY + exprPosY + posy]
 
     __withParentNode: (f) =>
@@ -143,7 +143,7 @@ export class Searcher extends ContainerComponent
             @parentNode = @parent.node @model.key
 
         unless @parentNode?
-            console.warn "[Searcher] Trying to perform an action on an unknown parent"
+            @warn "Trying to perform an action on an unknown parent"
 
         f @parentNode
 

--- a/src/view/Visualization.coffee
+++ b/src/view/Visualization.coffee
@@ -232,7 +232,7 @@ export class Visualization extends WidgetOld
                 @nodeEditor.topDomScene.model.add @view.obj
             else
                 @view.domElement.className = style.luna ['basegl-visualization--fullscreen']
-                @nodeEditor.topDomSceneNoScale.model.add @view.obj
+                @nodeEditor.topDomSceneStill.model.add @view.obj
                 @__forceUpdatePosition()
 
     updateView: => @withScene (scene) =>
@@ -318,7 +318,7 @@ export class VisualizerMenu extends WidgetOld
             else
                 @view.domElement.className = style.luna ['basegl-dropdown--fullscreen']
                 @menu?.className = style.luna ['basegl-dropdown__menu--fullscreen']
-                @nodeEditor.topDomSceneNoScale.model.add @view.obj
+                @nodeEditor.topDomSceneStill.model.add @view.obj
                 @__forceUpdatePosition()
 
     updateMenu: =>

--- a/src/widget/TextInput.coffee
+++ b/src/widget/TextInput.coffee
@@ -21,7 +21,7 @@ export class TextInput extends Widget
         if @changed.once
             @input = document.createElement 'input'
             @input.className = 'native-key-bindings ' + style.luna ['ctrl--text']
-            @def('root').__element.domElement.appendChild @input
+            @def('root').getDomElement().appendChild @input
         if @changed.width
             @input.style.width = @model.width + 'px'
         if @changed.height


### PR DESCRIPTION
This directly addresses https://github.com/luna/luna-studio/issues/960 because it is a reimplementation of the `Searcher` using the new component model. It also solves https://github.com/luna/luna-studio/issues/955 because it adds a next DOM layer that doesn't zoom. It is also addressing https://github.com/luna/luna-studio/issues/895 but this still needs some work.