### PR TITLE
Editable nodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 package-lock.json
 dist/js/bundle.js
+*.swp

--- a/package.json
+++ b/package.json
@@ -27,15 +27,15 @@
     "coffee-loader": "^0.9.0",
     "coffeescript": "next",
     "gl-matrix": "^2.4.0",
-    "webpack": "^3.9.1"
+    "webpack": "^3.9.1",
+    "webpack-dev-server": "^2.9.7"
   },
   "dependencies": {
     "basegl": "0.2.25",
     "bluebird": "^3.5.1",
     "glslify-loader": "^1.0.2",
     "raw-loader": "^0.5.1",
-    "underscore": "^1.9.0",
-    "webpack-dev-server": "^2.9.7"
+    "underscore": "^1.9.0"
   },
   "babel": {
     "presets": [

--- a/src/abstract/EventEmitter.coffee
+++ b/src/abstract/EventEmitter.coffee
@@ -17,7 +17,8 @@ export class EventEmitter extends PropertyEmitter
 
     eventKey: =>
         key = @parent?.eventKey?() or []
-        key.push @model.key if @model?.key?
+        if @model?.key? and (not (@model.key in key))
+            key.push @model.key
         key
 
     pushEvent: (e) =>

--- a/src/abstract/HasModel.coffee
+++ b/src/abstract/HasModel.coffee
@@ -59,4 +59,5 @@ export class HasModel extends EventEmitter
         @__view.removeChild view
         @__view.updateChildrenOrigin()
 
-    warn: (msg) => console.warn "[#{@constructor.name}] #{msg}"
+    log:  (msg) => console.log  "[#{@constructor.name}]", msg
+    warn: (msg) => console.warn "[#{@constructor.name}]", msg

--- a/src/main.coffee
+++ b/src/main.coffee
@@ -271,32 +271,32 @@ runExample = -> main (nodeEditor) ->
             dstNode: 4
             dstPort: 1
         ]
-    nodeEditor.setSearcher
-        key: 4
-        entries: [
-            name: 'bar'
-            doc:  'bar description'
-            className: 'Bar'
-            highlights:
-                [
-                    start: 1
-                    end: 2
-                ]
-        ,
-            name: 'foo'
-            doc:  'foo multiline\ndescription'
-            className: 'Foo'
-            highlights: []
-        ,
-            name: 'baz'
-            doc:  'baz description'
-            className: 'Test'
-            highlights:
-                [
-                    start: 1
-                    end: 3
-                ]
-        ]
+    # nodeEditor.setSearcher
+    #     key: 4
+    #     entries: [
+    #         name: 'bar'
+    #         doc:  'bar description'
+    #         className: 'Bar'
+    #         highlights:
+    #             [
+    #                 start: 1
+    #                 end: 2
+    #             ]
+    #     ,
+    #         name: 'foo'
+    #         doc:  'foo multiline\ndescription'
+    #         className: 'Foo'
+    #         highlights: []
+    #     ,
+    #         name: 'baz'
+    #         doc:  'baz description'
+    #         className: 'Test'
+    #         highlights:
+    #             [
+    #                 start: 1
+    #                 end: 3
+    #             ]
+    #     ]
 
     nodeEditor.setVisualizerLibraries
         internalVisualizersPath: ''

--- a/src/main.coffee
+++ b/src/main.coffee
@@ -271,32 +271,6 @@ runExample = -> main (nodeEditor) ->
             dstNode: 4
             dstPort: 1
         ]
-    # nodeEditor.setSearcher
-    #     key: 4
-    #     entries: [
-    #         name: 'bar'
-    #         doc:  'bar description'
-    #         className: 'Bar'
-    #         highlights:
-    #             [
-    #                 start: 1
-    #                 end: 2
-    #             ]
-    #     ,
-    #         name: 'foo'
-    #         doc:  'foo multiline\ndescription'
-    #         className: 'Foo'
-    #         highlights: []
-    #     ,
-    #         name: 'baz'
-    #         doc:  'baz description'
-    #         className: 'Test'
-    #         highlights:
-    #             [
-    #                 start: 1
-    #                 end: 3
-    #             ]
-    #     ]
 
     nodeEditor.setVisualizerLibraries
         internalVisualizersPath: ''

--- a/src/shape/Connection.coffee
+++ b/src/shape/Connection.coffee
@@ -53,5 +53,5 @@ export class ConnectionShape extends BasicComponent
 
     registerEvents: (view) =>
         vars = @getElement().variables
-        view.addEventListener 'mouseover', => console.log "Dupa";  vars.hovered = 1
-        view.addEventListener 'mouseout',  => console.log "Sraka"; vars.hovered = 0
+        view.addEventListener 'mouseover', => vars.hovered = 1
+        view.addEventListener 'mouseout',  => vars.hovered = 0

--- a/src/shape/Connection.coffee
+++ b/src/shape/Connection.coffee
@@ -53,5 +53,5 @@ export class ConnectionShape extends BasicComponent
 
     registerEvents: (view) =>
         vars = @getElement().variables
-        view.addEventListener 'mouseover', => vars.hovered = 1
-        view.addEventListener 'mouseout',  => vars.hovered = 0
+        view.addEventListener 'mouseover', => console.log "Dupa";  vars.hovered = 1
+        view.addEventListener 'mouseout',  => console.log "Sraka"; vars.hovered = 0

--- a/src/shape/Text.coffee
+++ b/src/shape/Text.coffee
@@ -1,5 +1,6 @@
 import * as basegl from 'basegl'
 import {BasicComponent}  from 'abstract/BasicComponent'
+import {ContainerComponent}  from 'abstract/ContainerComponent'
 
 
 export class TextShape extends BasicComponent

--- a/src/shape/Text.coffee
+++ b/src/shape/Text.coffee
@@ -25,8 +25,7 @@ export class TextShape extends BasicComponent
                 0
         element.position.y = - size[1]/2
 
-    size:   =>
-        getTextSize   @__element
+    size:   => getTextSize   @__element
     width:  => getTextWidth  @__element
     height: => getTextHeight @__element
 

--- a/src/view/EditableText.coffee
+++ b/src/view/EditableText.coffee
@@ -1,0 +1,76 @@
+import {ContainerComponent} from 'abstract/ContainerComponent'
+import {Searcher}           from 'view/Searcher'
+import {TextShape}          from 'shape/Text'
+
+import * as basegl from 'basegl'
+import * as style  from 'style'
+import * as shape  from 'shape/node/Base'
+
+
+export class EditableText extends ContainerComponent
+
+    ################################
+    ### Initialize the component ###
+    ################################
+
+    initModel: =>
+        key: null
+        input: null
+        text: ''
+        inputSelection: null
+        selected: 0
+        entries: []
+        position: [0, 0]
+        edited: false
+
+    prepare: =>
+        console.log "EditableText::prepare"
+        # console.log "@model: ", @model
+
+        @addDef 'text', new TextShape
+                text: @model.text
+            , @
+        @addDef 'searcher', new Searcher
+                key:            @model.key
+                input:          @model.input
+                text:           @model.text
+                inputSelection: @model.inputSelection
+                selected:       @model.selected
+                entries:        @model.entries
+                position:       @model.position
+            , @
+
+    #############################
+    ### Create/update the DOM ###
+    #############################
+
+    update: =>
+        console.log "EditableText::update"
+        console.log "@model: ", @model
+        @updateDef 'searcher', entries: @model.entries
+
+    #######################
+    ### Adjust the view ###
+    #######################
+
+    adjust: (view) =>
+        console.log "EditableText::adjust"
+    
+    __onPositionChanged: (parentNode) =>
+        console.log "Changing position along with the parent"
+        @set position: parentNode.model.position
+
+    ###################################
+    ### Register the event handlers ###
+    ###################################
+
+    registerEvents: (view) =>
+        console.log "EditableText::registerEvents"
+        @view('text').addEventListener 'dblclick', (e) => console.log "Doubleclick on #{@model.text}"
+        view.addEventListener 'mouseenter', => console.log "Siup"
+        
+        parentNode = @model.parent
+        if parentNode?
+            @__onPositionChanged parentNode
+            @addDisposableListener parentNode, 'position', =>
+                @__onPositionChanged parentNode

--- a/src/view/EditableText.coffee
+++ b/src/view/EditableText.coffee
@@ -39,19 +39,15 @@ export class EditableText extends ContainerComponent
         anyChanged = Object.values(@changed).some((v) -> v)
         return unless anyChanged
 
-        if @model.edited
-            @autoUpdateDef 'searcher', Searcher,
-                    key:            @model.key
-                    input:          @model.input || @model.text
-                    inputSelection: @model.inputSelection
-                    selected:       @model.selected
-                    entries:        @model.entries
-            @autoUpdateDef 'text', TextContainer, null
-        else
-            @autoUpdateDef 'searcher', Searcher, null
-            @autoUpdateDef 'text', TextContainer,
-                    text:  @model.text
-                    align: 'center'
+        @autoUpdateDef 'searcher', Searcher, if @model.edited
+            key:            @model.key
+            input:          @model.input || ""
+            inputSelection: @model.inputSelection
+            selected:       @model.selected
+            entries:        @model.entries
+        @autoUpdateDef 'text', TextContainer, unless @model.edited
+            text:  @model.text
+            align: 'center'
 
     hideSearcher: =>
         @set edited: false
@@ -61,7 +57,9 @@ export class EditableText extends ContainerComponent
         @set edited: true
         @root.registerSearcher @
         tag = if (@model.kind == EditableText.NAME)
-        then 'EditNodeNameEvent' else 'EditNodeExpressionEvent'
+                'EditNodeNameEvent'
+            else
+                'EditNodeExpressionEvent'
         if notify
             @pushEvent tag: tag
 

--- a/src/view/EditableText.coffee
+++ b/src/view/EditableText.coffee
@@ -50,7 +50,8 @@ export class EditableText extends ContainerComponent
         else
             @autoUpdateDef 'searcher', Searcher, null
             @autoUpdateDef 'text', TextContainer,
-                    text: @model.text
+                    text:  @model.text
+                    align: 'center'
 
     hideSearcher: =>
         @set edited: false

--- a/src/view/ExpressionNode.coffee
+++ b/src/view/ExpressionNode.coffee
@@ -28,7 +28,7 @@ selectedNode = null
 
 
 nodeExprYOffset = shape.height / 3
-nodeNameYOffset = nodeExprYOffset + 15
+nodeNameYOffset = nodeExprYOffset + 25
 nodeValYOffset  = -nodeNameYOffset
 
 portDistance = shape.height / 3

--- a/src/view/ExpressionNode.coffee
+++ b/src/view/ExpressionNode.coffee
@@ -58,13 +58,16 @@ export class ExpressionNode extends ContainerComponent
 
     prepare: =>
         @addDef 'node', new NodeShape expanded: @model.expanded, @
-        @addDef 'expression', new TextContainer text: @model.expression, @
         @addDef 'name', new EditableText
                 text:     @model.name
-                entries:  testEntries
-                position: @model.position
+                entries:  []
+                kind:     EditableText.NAME
             , @
-        @addDef 'expression', new TextShape text: @model.expression, @
+        @addDef 'expression', new EditableText
+                text:    @model.expression
+                entries: []
+                kind:    EditableText.EXPRESSION
+            , @
         @addDef 'valueToggler', new ValueTogglerShape null, @
 
     update: =>
@@ -123,14 +126,9 @@ export class ExpressionNode extends ContainerComponent
         if @model.value? and @model.value.contents?
             @model.value.contents.contents
 
-    # updateValueView: =>
-    #     valueSize     = [0,0]
-    #     valuePosition = @view('node').position
-    #     if @__shortValue()?
-    #         @view('value').position.y = @view('node').position.y
-    #         valuePosition = @view('value').position
-    #     @view('valueToggler').position.y = @view('node').position.y
-        
+    setSearcher: (searcherModel) =>
+        @def(searcherModel.targetField)?.setSearcher searcherModel
+
     adjust: (view) =>
         if @model.expanded
             for own inPortKey, inPortModel of @model.inPorts
@@ -139,7 +137,7 @@ export class ExpressionNode extends ContainerComponent
                     leftOffset = 50
                     startPoint = [inPort.model.position[0] + leftOffset, inPort.model.position[1]]
                     @view('widget' + inPortKey).position.xy = startPoint
-        # @updateValueView()
+
         if @__shortValue()?
             @view('value').position.xy =
                 if @model.expanded

--- a/src/view/ExpressionNode.coffee
+++ b/src/view/ExpressionNode.coffee
@@ -26,9 +26,9 @@ import {HorizontalLayout}   from 'widget/HorizontalLayout'
 selectedNode = null
 
 
-
+exprOffset = 25
 nodeExprYOffset = shape.height / 3
-nodeNameYOffset = nodeExprYOffset + 25
+nodeNameYOffset = nodeExprYOffset + exprOffset
 nodeValYOffset  = -nodeNameYOffset
 
 portDistance = shape.height / 3

--- a/src/view/ExpressionNode.coffee
+++ b/src/view/ExpressionNode.coffee
@@ -9,6 +9,7 @@ import {Composable, fieldMixin} from "basegl/object/Property"
 
 import {InPort}             from 'view/port/In'
 import {OutPort}            from 'view/port/Out'
+import {EditableText}       from 'view/EditableText'
 import * as shape           from 'shape/node/Base'
 import * as togglerShape    from 'shape/node/ValueToggler'
 import * as _               from 'underscore'
@@ -36,6 +37,12 @@ widgetHeight = 20
 inportVDistance = widgetOffset + widgetHeight
 minimalBodyHeight = 60
 
+testEntries = [
+    { name: 'bar', doc: 'bar description', className: 'Bar', highlights: [ { start: 1, end: 2 } ] },
+    { name: 'foo', doc: 'foo multiline\ndescription', className: 'Foo', highlights: [] },
+    { name: 'baz', doc:  'baz description', className: 'Test', highlights: [ { start: 1, end: 3 } ] }
+]
+
 export class ExpressionNode extends ContainerComponent
     initModel: =>
         key:        null
@@ -51,8 +58,13 @@ export class ExpressionNode extends ContainerComponent
 
     prepare: =>
         @addDef 'node', new NodeShape expanded: @model.expanded, @
-        @addDef 'name', new TextContainer text: @model.name, @
         @addDef 'expression', new TextContainer text: @model.expression, @
+        @addDef 'name', new EditableText
+                text:     @model.name
+                entries:  testEntries
+                position: @model.position
+            , @
+        @addDef 'expression', new TextShape text: @model.expression, @
         @addDef 'valueToggler', new ValueTogglerShape null, @
 
     update: =>

--- a/src/view/ExpressionNode.coffee
+++ b/src/view/ExpressionNode.coffee
@@ -58,7 +58,6 @@ export class ExpressionNode extends ContainerComponent
 
     prepare: =>
         @addDef 'node', new NodeShape expanded: @model.expanded, @
-<<<<<<< HEAD
         @addDef 'name', new EditableText
                 text:     @model.name
                 entries:  []

--- a/src/view/InputNode.coffee
+++ b/src/view/InputNode.coffee
@@ -41,7 +41,7 @@ export class InputNode extends ContainerComponent
             @set position: [x, y]
 
     connectSources: =>
-        # @log "CONNECT SOURCES"
+        # NOTE[piotrMocz] this is what impacts the performance HARD.
         # @withScene (scene) =>
         #     @addDisposableListener scene.camera, 'move', =>
         #         campos = scene.camera.position

--- a/src/view/InputNode.coffee
+++ b/src/view/InputNode.coffee
@@ -41,12 +41,13 @@ export class InputNode extends ContainerComponent
             @set position: [x, y]
 
     connectSources: =>
-        @withScene (scene) =>
-            @addDisposableListener scene.camera, 'move', =>
-                campos = scene.camera.position
-                x = scene.width/2 + campos.x - scene.width/2*campos.z
-                y = scene.height/2 + campos.y - height/2
-                @align x, y
+        # @log "CONNECT SOURCES"
+        # @withScene (scene) =>
+        #     @addDisposableListener scene.camera, 'move', =>
+        #         campos = scene.camera.position
+        #         x = scene.width/2 + campos.x - scene.width/2*campos.z
+        #         y = scene.height/2 + campos.y - height/2
+        #         @align x, y
 
     outPort: (key) => @def ('out' + key)
 

--- a/src/view/NodeEditor.coffee
+++ b/src/view/NodeEditor.coffee
@@ -102,13 +102,11 @@ export class NodeEditor extends EventEmitter
         @genericSetComponent 'inputNode', InputNode, inputNode
     setOutputNode: (outputNode) =>
         @genericSetComponent 'outputNode', OutputNode, outputNode
-    setSearcher: (searcher) =>
-        @genericSetComponent 'searcher', Searcher, searcher
-    
+
     setVisualizerLibraries: (visLib) =>
         unless _.isEqual(@visualizerLibraries, visLib)
             @emitProperty 'visualizerLibraries', visLib
-    
+
     setVisualization: (nodeVis) =>
         key = nodeVis.nodeKey
         if @visualizations[key]?
@@ -120,7 +118,7 @@ export class NodeEditor extends EventEmitter
             if @visualizations[key]?
                 @visualizations[key].dispose()
                 delete @visualizations[key]
-        
+
     unsetVisualization: (nodeVis) =>
         if @visualizations[nodeVis.nodeKey]?
             @visualizations[nodeVis.nodeKey].dispose()
@@ -193,3 +191,28 @@ export class NodeEditor extends EventEmitter
             @connections[connectionKey].dispose()
         for nodeKey in Object.keys @nodes
             @nodes[nodeKey].dispose()
+
+    setSearcher: (searcherModel) =>
+        unless searcherModel?
+            @unregisterSearcher()
+            return
+
+        node = @node(searcherModel.key)
+        unless node?
+            @warn "No node to attatch the Searcher to."
+            return
+
+        node.setSearcher searcherModel
+
+    unregisterSearcher: =>
+        if @openSearcher?
+            closingSearcher = @openSearcher
+            @openSearcher = null
+            closingSearcher.hideSearcher()
+
+    registerSearcher: (searcher) =>
+        if @openSearcher? and searcher.key != @openSearcher.key
+            @openSearcher.hideSearcher()
+        @openSearcher = searcher
+
+    log: (msg) => console.log "[NodeEditor]", msg

--- a/src/view/Searcher.coffee
+++ b/src/view/Searcher.coffee
@@ -73,11 +73,12 @@ export class Searcher extends ContainerComponent
 
     __updateResults: =>
         @dom.resultsList.innerText = ''
-        i = 0
-        @model.entries.forEach (entry) =>
-            highlight = (i == 0) and (@model.selected != 0)
-            @dom.resultsList.appendChild @__renderResult entry, highlight
-            i++
+        return unless @model.entries.length > 0
+
+        firstResult = @__renderResult @model.entries[0], @model.selected != 0
+        @dom.resultsList.appendChild firstResult
+        @model.entries[1..].forEach (entry) =>
+            @dom.resultsList.appendChild @__renderResult entry, false
 
     __updateInput: =>
         inputClasses = ['searcher__input']
@@ -143,17 +144,17 @@ export class Searcher extends ContainerComponent
                 editSelectionEnd:   @dom.input.selectionEnd
                 editValue:          @dom.input.value
         @dom.input.addEventListener 'keyup', (e) =>
-            if e.code == 'Enter'
+            if e.key == 'Enter'
                 @pushEvent
                     tag: 'SearcherAcceptEvent'
                     acceptSelectionStart: @dom.input.selectionStart
                     acceptSelectionEnd:   @dom.input.selectionEnd
                     acceptValue:          @dom.input.value
-            else if e.code == 'Tab'
+            else if e.key == 'Tab'
                 @pushEvent tag: 'SeacherTabPressedEvent'
 
         @dom.input.addEventListener 'keydown', (e) =>
-            if e.code == 'ArrowUp'
+            if e.key == 'ArrowUp'
                 @pushEvent tag: 'SearcherMoveUpEvent'
-            else if e.code == 'ArrowDown'
+            else if e.key == 'ArrowDown'
                 @pushEvent tag: 'SearcherMoveDownEvent'

--- a/src/view/Searcher.coffee
+++ b/src/view/Searcher.coffee
@@ -75,7 +75,8 @@ export class Searcher extends ContainerComponent
         @dom.resultsList.innerText = ''
         i = 0
         @model.entries.forEach (entry) =>
-            @dom.resultsList.appendChild @__renderResult entry, i == 0
+            highlight = (i == 0) and (@model.selected != 0)
+            @dom.resultsList.appendChild @__renderResult entry, highlight
             i++
 
     __updateInput: =>

--- a/src/view/Searcher.coffee
+++ b/src/view/Searcher.coffee
@@ -73,8 +73,6 @@ export class Searcher extends ContainerComponent
 
     __updateResults: =>
         @dom.resultsList.innerText = ''
-        # omit = Math.max(0, @model.selected - 1)
-        # i = omit + 1
         i = 0
         @model.entries.forEach (entry) =>
             @dom.resultsList.appendChild @__renderResult entry, i == 0

--- a/src/view/Searcher.coffee
+++ b/src/view/Searcher.coffee
@@ -19,14 +19,17 @@ export class Searcher extends ContainerComponent
     ################################
 
     initModel: =>
+        console.log "Searcher: init model"
         key: null
         input: null
         inputSelection: null
         selected: 0
         entries: []
         position: [0, 0]
+        parent: null
 
     prepare: =>
+        console.log "===== Searcher: prepare ======"
         @dom = {}
         @addDef 'root', new HtmlShape
                 element: 'div'
@@ -39,6 +42,7 @@ export class Searcher extends ContainerComponent
     #############################
 
     update: =>
+        console.log "Searcher: update"
         @__createDom() unless @dom.container?
         @__updateResults() if @changed.entries
         @__updateInput() if @changed.input
@@ -132,15 +136,19 @@ export class Searcher extends ContainerComponent
     #######################
 
     adjust: (view) =>
+        console.log "Searcher : adjust"
         if @changed.position
             @__withParentNode (parentNode) =>
                 [posx, posy] = @model.position.slice()
-                exprPosY = parentNode.view('expression').position.y
-                view.position.xy = [searcherBaseOffsetX + posx, searcherBaseOffsetY + exprPosY + posy]
+                exprPosY = parentNode.view('text').position.y
+                # view.position.xy = [searcherBaseOffsetX + posx, searcherBaseOffsetY + exprPosY + posy]
 
     __withParentNode: (f) =>
         unless @parentNode?
-            @parentNode = @parent.node @model.key
+            if @parent.node?
+                @parentNode = @parent.node @model.key
+            else
+                @parentNode = @parent
 
         unless @parentNode?
             @warn "Trying to perform an action on an unknown parent"

--- a/update_statics.sh
+++ b/update_statics.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-echo "Installing the package..."
-npm install
-echo "Done."
+# echo "Installing the package..."
+# npm install
+# echo "Done."
 
 echo "Running webpack..."
 npm run build


### PR DESCRIPTION
Now the searcher is a part of the name/expression. The names and expressions are now `EditableText`s that handle hiding and showing of the searcher. This makes the hiding/showing logic a bit more involved, but in return basically removes the need to position the searcher in any way.

Also, the handling of scrolling through the searcher is a bit simplified by just truncating the list of entries Haskell-gui-side.