### PR TITLE
Make the HtmlShapes clickable

### DIFF
--- a/src/shape/Html.coffee
+++ b/src/shape/Html.coffee
@@ -9,6 +9,7 @@ export class HtmlShape extends BasicComponent
         top: true
         scalable: true
         still: false
+        clickable: true
 
     redefineRequired: =>
         @changed.id or @changed.element
@@ -16,6 +17,7 @@ export class HtmlShape extends BasicComponent
     define: =>
         root = document.createElement @model.element
         root.id = @model.id if @model.id?
+        root.style.pointerEvents = if @model.clickable then 'all' else 'none'
         basegl.symbol root
 
     adjust: =>
@@ -27,9 +29,9 @@ export class HtmlShape extends BasicComponent
                 @root.topDomSceneNoScale.model.add obj
             else if @model.top
                 @root.topDomScene.model.add obj
-                @__forceUpdatePosition()
             else
                 @root.scene.domModel.model.add @view.obj
+            @__forceUpdatePosition()
 
     # FIXME: This function is needed due to bug in basegl or THREE.js
     # which causes problems with positioning when layer changed

--- a/src/view/NodeEditor.coffee
+++ b/src/view/NodeEditor.coffee
@@ -29,9 +29,6 @@ export class NodeEditor extends EventEmitter
         @topDomSceneStill     = @_scene.addDomModelWithNewCamera('dom-top-still')
         @topDomSceneNoScale   =
             @_scene.addDomModelWithNewCamera('dom-top-no-scale', new ZoomlessCamera @_scene._camera)
-        @topDomScene._renderer.domElement.style.pointerEvents='all'
-        @topDomSceneStill._renderer.domElement.style.pointerEvents='all'
-        @topDomSceneNoScale._renderer.domElement.style.pointerEvents='all'
 
         visCoverFamily = @_scene.register visualizationCover
         visCoverFamily.zIndex = -1


### PR DESCRIPTION
Introduces a `clickable` property of `HtmlShape`, semantics of which are fairly self-explanatory. Defaults to `true`.