### PR TITLE
Fix the excessive number of UI updates for InputNodes

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "webpack-dev-server": "^2.9.7"
   },
   "dependencies": {
-    "basegl": "0.2.25",
+    "basegl": "0.2.26",
     "bluebird": "^3.5.1",
     "glslify-loader": "^1.0.2",
     "raw-loader": "^0.5.1",

--- a/src/view/InputNode.coffee
+++ b/src/view/InputNode.coffee
@@ -4,7 +4,9 @@ import * as basegl     from 'basegl'
 import {FlatPort}      from 'view/port/Flat'
 import {AddPortShape}  from 'shape/port/Add'
 
+
 height = 100
+
 
 export class InputNode extends ContainerComponent
     initModel: =>
@@ -31,24 +33,24 @@ export class InputNode extends ContainerComponent
         @addPortPosition = newPosition()
 
     adjust: (view) =>
-        @view('add').position.xy = [ @addPortPosition[0]
-                                   , @addPortPosition[1]
-                                   ]
+        if @changed.outPorts
+            @view('add').position.xy = [
+                @addPortPosition[0], @addPortPosition[1]
+            ]
+
         if @changed.position
             view.position.xy = @model.position.slice()
 
-    align: (x, y) =>
-        unless x == @model.position[0] and y == @model.position[1]
-            @set position: [x, y]
+    _align: (scene) =>
+        campos = scene.camera.position
+        x = scene.width/2 + campos.x - scene.width/2*campos.z
+        y = scene.height/2 + campos.y - height/2
+        @set position: [x, y]
 
     connectSources: =>
-        # NOTE[piotrMocz] this is what impacts the performance HARD.
         @withScene (scene) =>
-            @addDisposableListener scene.camera, 'move', =>
-                campos = scene.camera.position
-                x = scene.width/2 + campos.x - scene.width/2*campos.z
-                y = scene.height/2 + campos.y - height/2
-                @align x, y
+            @_align scene
+            @addDisposableListener scene.camera, 'move', => @_align scene
 
     outPort: (key) => @def ('out' + key)
 

--- a/src/view/InputNode.coffee
+++ b/src/view/InputNode.coffee
@@ -16,6 +16,7 @@ export class InputNode extends ContainerComponent
         @addDef 'add', new AddPortShape null, @
 
     update: =>
+        return unless @changed.outPorts
         i = 0
         keys = Object.keys @model.outPorts
         portOffset = height / keys.length
@@ -42,12 +43,12 @@ export class InputNode extends ContainerComponent
 
     connectSources: =>
         # NOTE[piotrMocz] this is what impacts the performance HARD.
-        # @withScene (scene) =>
-        #     @addDisposableListener scene.camera, 'move', =>
-        #         campos = scene.camera.position
-        #         x = scene.width/2 + campos.x - scene.width/2*campos.z
-        #         y = scene.height/2 + campos.y - height/2
-        #         @align x, y
+        @withScene (scene) =>
+            @addDisposableListener scene.camera, 'move', =>
+                campos = scene.camera.position
+                x = scene.width/2 + campos.x - scene.width/2*campos.z
+                y = scene.height/2 + campos.y - height/2
+                @align x, y
 
     outPort: (key) => @def ('out' + key)
 

--- a/src/view/OutputNode.coffee
+++ b/src/view/OutputNode.coffee
@@ -6,6 +6,7 @@ import {FlatPort}           from 'view/port/Flat'
 
 height = 100
 
+
 export class OutputNode extends ContainerComponent
     initModel: =>
         key:      null
@@ -27,61 +28,18 @@ export class OutputNode extends ContainerComponent
         if @changed.position
             view.position.xy = @model.position.slice()
 
-    align: (x, y) =>
-        unless x == @model.position[0] and y == @model.position[1]
-            @set position: [x, y]
+    _align: (scene) =>
+        campos = scene.camera.position
+        x = scene.width/2 + campos.x + scene.width/2*campos.z
+        y = scene.height/2 + campos.y - height/2
+        @set position: [x, y]
 
     connectSources: =>
         @withScene (scene) =>
-            @addDisposableListener scene.camera, 'move', =>
-                campos = scene.camera.position
-                x = scene.width/2 + campos.x + scene.width/2*campos.z
-                y = scene.height/2 + campos.y - height/2
-                @align x, y
+            @_align scene
+            @addDisposableListener scene.camera, 'move', => @_align scene
 
     outPort: (key) => @def ('out' + key)
 
     inPort: (key) => @def ('in' + key)
-
-# height = 100
-
-# export class InputNode extends ContainerComponent
-#     initModel: =>
-#         key: null
-#         outPorts: {}
-#         position: [0, 0]
-    
-#     prepare: =>
-#         @addDef 'add', new AddPortShape null, @
-    
-#     update: =>
-#         i = 0
-#         keys = Object.keys @model.outPorts
-#         portOffset = height / keys.length
-#         newPosition = =>
-#             pos = [ 0 , 0 + portOffset * keys.length - i * portOffset]
-#             i++
-#             return pos
-#         for own k, outPort of @model.outPorts
-#             outPort.position = newPosition()
-#             @autoUpdateDef ('out' + k), FlatPort, outPort
-#         @addPortPosition = newPosition()
-
-#     adjust: (view) =>
-#         @view('add').position.xy = [ @addPortPosition[0]
-#                                    , @addPortPosition[1]
-#                                    ]
-#         view.position.xy = @model.position.slice()
-        
-#     align: (x, y) =>
-#         unless x == @model.position[0] and y == @model.position[1]
-#             @set position: [x, y]
-
-#     connectSources: =>
-#         @withScene (scene) =>
-#             @addDisposableListener scene.camera, 'move', =>
-#                 campos = scene.camera.position
-#                 x = scene.width/2 + campos.x - scene.width/2*campos.z
-#                 y = scene.height/2 + campos.y - height/2
-#                 @align x, y
 

--- a/src/view/OutputNode.coffee
+++ b/src/view/OutputNode.coffee
@@ -13,6 +13,7 @@ export class OutputNode extends ContainerComponent
         position: [0,0]
 
     update: =>
+        return unless @changed.inPorts
         i = 0
         keys = Object.keys @model.inPorts
         portOffset = height / keys.length


### PR DESCRIPTION
This:
* prevents the `InputNode` from re-constructing itself on every position change.
* switches to the new version of basegl that doesn't issue camera move events when everything is still.