### PR TITLE
Fix clickability of node name and expr

### DIFF
--- a/src/view/Text.coffee
+++ b/src/view/Text.coffee
@@ -26,9 +26,7 @@ export class TextContainer extends Widget
 
     update: =>
         if @changed.text
-            @updateDef 'text',
-                text: @model.text
-        if @changed.text
+            @updateDef 'text', text: @model.text
             size = @def('text').size()
             @__minWidth = size[0]
             @__minHeight = size[1]
@@ -36,10 +34,7 @@ export class TextContainer extends Widget
                 @updateDef 'box', height: @__minHeight
             unless @model.width
                 @updateDef 'box', width: @__minWidth
-        if @changed.height
-            @updateDef 'box', height: @model.height
-        if @changed.width
-            @updateDef 'box', width: @model.width
+
         if @changed.frameVisible
             @updateDef 'box', visible: @model.frameVisible
         if @changed.frameColor

--- a/src/view/Text.coffee
+++ b/src/view/Text.coffee
@@ -27,13 +27,13 @@ export class TextContainer extends Widget
     update: =>
         if @changed.text
             @updateDef 'text', text: @model.text
+        
+        if @changed.text or @changed.height or @changed.width
             size = @def('text').size()
-            @__minWidth = size[0]
+            @__minWidth  = size[0]
             @__minHeight = size[1]
-            unless @model.height
-                @updateDef 'box', height: @__minHeight
-            unless @model.width
-                @updateDef 'box', width: @__minWidth
+            @updateDef 'box', height: @model.height or @__minHeight
+            @updateDef 'box', width:  @model.width  or @__minWidth
 
         if @changed.frameVisible
             @updateDef 'box', visible: @model.frameVisible


### PR DESCRIPTION
If `height` or `witdth` weren't explicitly specified, the second and third ifs were overwriting the `height` parameter of `def('box')` and consequently making the size of the rectangle `[0, 0]` ;)