### PR TITLE
HtmlShape fix

### DIFF
--- a/src/abstract/BasicComponent.coffee
+++ b/src/abstract/BasicComponent.coffee
@@ -1,5 +1,4 @@
 import {HasModel}  from "abstract/HasModel"
-import * as _      from 'underscore'
 import * as basegl from 'basegl/display/Symbol'
 
 
@@ -18,7 +17,7 @@ export class BasicComponent extends HasModel
     onModelUpdate: =>
         if (@redefineRequired? and @redefineRequired(@changed)) or (not @__def?)
             def = @define()
-            if def? and not _.isEqual(def, @__def)
+            if def?
                 @__undraw()
                 @__draw def
                 @__def = def

--- a/src/abstract/ContainerComponent.coffee
+++ b/src/abstract/ContainerComponent.coffee
@@ -33,14 +33,14 @@ export class ContainerComponent extends HasModel
             @__defs[key] = def
             @__addToGroup def.__view
         else unless _.isEqual @__defs[key], def
-            @__removeFromGroup @__defs[key]
+            @__removeFromGroup @__defs[key].__view
             @__defs[key].dispose()
             @__addToGroup def.__view
             @__defs[key] = def
 
     deleteDef: (key) =>
         if @__defs[key]?
-            @__removeFromGroup @__defs[key]
+            @__removeFromGroup @__defs[key].__view
             @__defs[key].dispose()
             delete @__defs[key]
 

--- a/src/abstract/HasModel.coffee
+++ b/src/abstract/HasModel.coffee
@@ -2,6 +2,7 @@ import {EventEmitter} from "abstract/EventEmitter"
 import * as basegl    from 'basegl/display/Symbol'
 import * as _         from 'underscore'
 
+
 unArray = (ref, obj) =>
     if ref? and (not Array.isArray ref) and Array.isArray obj
         ret = {}
@@ -50,7 +51,7 @@ export class HasModel extends EventEmitter
                 @model[key] = value
                 @performEmit key, value
 
-    __addToGroup:      (view) =>
+    __addToGroup: (view) =>
         @__view.addChild view
         @__view.updateChildrenOrigin()
 

--- a/src/shape/Html.coffee
+++ b/src/shape/Html.coffee
@@ -6,22 +6,30 @@ export class HtmlShape extends BasicComponent
     initModel: =>
         id: null
         element: 'div'
+        width: null
+        height: null
         top: true
         scalable: true
         still: false
         clickable: true
 
-    redefineRequired: =>
-        @changed.id or @changed.element
+    redefineRequired: => @changed.element
 
     define: =>
-        root = document.createElement @model.element
-        root.id = @model.id if @model.id?
-        root.style.pointerEvents = if @model.clickable then 'all' else 'none'
-        basegl.symbol root
+        @html = document.createElement @model.element
+        basegl.symbol @html
 
     adjust: =>
-        if @changed.top or @changed.scalable
+        if @changed.id
+            @getDomElement().id = @model.id
+        if @changed.width
+            @getDomElement().style.width = @model.width
+        if @changed.height
+            @getDomElement().style.height = @model.height
+        if @changed.clickable
+            @getDomElement().style.pointerEvents = if @model.clickable then 'all' else 'none'
+
+        if @changed.top or @changed.scalable or @changed.still
             obj = @getElement().obj
             if @model.still
                 @root.topDomSceneStill.model.add obj
@@ -30,12 +38,12 @@ export class HtmlShape extends BasicComponent
             else if @model.top
                 @root.topDomScene.model.add obj
             else
-                @root.scene.domModel.model.add @view.obj
+                @root._scene.domModel.model.add obj
             @__forceUpdatePosition()
 
     # FIXME: This function is needed due to bug in basegl or THREE.js
     # which causes problems with positioning when layer changed
     __forceUpdatePosition: =>
-        if @getElement()?
-            elem = @getElement()
+        elem = @getElement()
+        if elem?
             elem.position.y = if elem.position.y == 0 then 1 else 0


### PR DESCRIPTION
This PR fixes HtmlShapes redefine logic. Most of model updates was handled in `define` which was not fired, because `redefineRequired` was not pointing that it is neccessary. Also, there is no need to redefine whole html tree if we can change width, height or some styles. This PR fixes that.

Also, removing components from groups did not work at all, and this PR fixes that too.