### PR TITLE
Display port background when it is not connected. #70

### DIFF
--- a/src/shape/port/Base.coffee
+++ b/src/shape/port/Base.coffee
@@ -9,8 +9,13 @@ export offset = (style) -> style.port_length - 2
 
 
 export class PortShape extends BasicComponent
-    initModel: => color: [1,0,0]
+    initModel: =>
+        color: [1,0,0]
+        connected: false
+
     adjust: (element) =>
+        if @changed.connected
+            element.variables.connected = Number @model.connected
         if @changed.color
             element.variables.color_r = @model.color[0]
             element.variables.color_g = @model.color[1]

--- a/src/shape/port/Flat.coffee
+++ b/src/shape/port/Flat.coffee
@@ -34,6 +34,7 @@ flatPortSymbol = memoizedSymbol (style) ->
     symbol.variables.color_g = 0
     symbol.variables.color_b = 0
     symbol.variables.hovered = 0
+    symbol.variables.connected = 0
     symbol.variables.is_output = 0
     symbol.defaultZIndex = layers.flatPort
     symbol

--- a/src/shape/port/In.coffee
+++ b/src/shape/port/In.coffee
@@ -22,6 +22,8 @@ inPortExpr = (style) -> basegl.expr ->
        .rotate Math.PI
        .move bboxWidth(style)/2, portBase.distanceFromCenter(style)
     port = c * p
+    background = port.grow style.port_bgSize*(1-'connected')
+        .fill color.bg style
     port = port.fill color.varAlphaHover style
     activeCutter = circle style.node_radius
         .move bboxWidth(style)/2, 0
@@ -30,7 +32,7 @@ inPortExpr = (style) -> basegl.expr ->
         .move bboxWidth(style)/2, 0
         .fill color.activeArea
     activeArea = activeArea - activeCutter
-    activeArea + port
+    activeArea + background + port
 
 inPortSymbol = memoizedSymbol (style) ->
     symbol = basegl.symbol inPortExpr style
@@ -40,6 +42,7 @@ inPortSymbol = memoizedSymbol (style) ->
     symbol.variables.color_b = 0
     symbol.variables.color_a = 1
     symbol.variables.hovered = 0
+    symbol.variables.connected = 0
     symbol.defaultZIndex = layers.inPort
     symbol
 

--- a/src/shape/port/Out.coffee
+++ b/src/shape/port/Out.coffee
@@ -18,9 +18,11 @@ export outPortExpr = (style) -> basegl.expr ->
     h2 = style.port_length - r + r * Math.cos Math.asin ((2*style.port_length*Math.tan (style.port_angle/2))/r )
     p = pie style.port_angle
        .move bboxWidth(style)/2, h2 + r
-    port = p - c
-    port = port.move 0, - r + style.port_length - h2 + portBase.distanceFromCenter(style)
-        .fill color.varHover style
+    port = (p - c)
+        .move 0, - r + style.port_length - h2 + portBase.distanceFromCenter(style)
+    background = port.grow style.port_bgSize*(1-'connected')
+        .fill color.bg style
+    port = port.fill color.varHover style
     activeCutter = circle style.node_radius
         .move bboxWidth(style)/2, 0
     activeArea = pie areaAngle
@@ -28,7 +30,7 @@ export outPortExpr = (style) -> basegl.expr ->
         .move bboxWidth(style)/2, 0
         .fill color.activeArea
     activeArea = activeArea - activeCutter
-    activeArea + port
+    activeArea + background + port
 
 outPortSymbol = memoizedSymbol (style) ->
     symbol = basegl.symbol outPortExpr style
@@ -37,12 +39,12 @@ outPortSymbol = memoizedSymbol (style) ->
     symbol.variables.color_g = 0
     symbol.variables.color_b = 0
     symbol.variables.hovered = 0
+    symbol.variables.connected = 0
     symbol.defaultZIndex = layers.outPort
     symbol
 
 export class OutPortShape extends PortShape
     define: => outPortSymbol @style
-
     adjust: (element) =>
         super element
         element.position.xy = [-bboxWidth(@style)/2, -portBase.distanceFromCenter(@style) - portBase.offset(@style)]

--- a/src/shape/port/Self.coffee
+++ b/src/shape/port/Self.coffee
@@ -21,6 +21,7 @@ selfPortSymbol = memoizedSymbol (style) ->
     symbol.variables.color_g = 0
     symbol.variables.color_b = 0
     symbol.variables.hovered = 0
+    symbol.variables.connected = 0
     symbol.defaultZIndex = layers.selfPort
     symbol
 

--- a/src/view/Styles.coffee
+++ b/src/view/Styles.coffee
@@ -84,6 +84,7 @@ presets =
         port_borderColor_s: 0.00001
         port_borderColor_l: 0.93
         port_borderColor_a: 1
+        port_bgSize: 2
         connection_lineWidth: 2
         colorActiveGreen_r: 0
         colorActiveGreen_g: 1

--- a/src/view/port/Out.coffee
+++ b/src/view/port/Out.coffee
@@ -1,4 +1,3 @@
-import {FlatPortShape}      from 'shape/port/Flat'
 import {Port, defaultColor} from 'view/port/Base'
 import {OutArrow}           from 'view/port/sub/OutArrow'
 
@@ -21,20 +20,22 @@ export class OutPort extends Port
                 @deleteDef 'subport'
             @updateDef 'subports',
                 elems: for own k, subport of @model.subports
-                    angle:    subport
-                    color:    @model.color
-                    hovered:  @model.hovered
-                    key:      k
-                    radius:   @model.radius
-                    typeName: @model.typeName
+                    angle:     subport
+                    connected: true
+                    color:     @model.color
+                    hovered:   @model.hovered
+                    key:       k
+                    radius:    @model.radius
+                    typeName:  @model.typeName
         else
             @updateDef 'subports', elems: []
             @autoUpdateDef 'subport', OutArrow,
-                angle:    @model.angle
-                color:    @model.color
-                hovered:  @model.hovered
-                radius:   @model.radius
-                typeName: @model.typeName
+                angle:     @model.angle
+                connected: (Object.keys @model.subports).length > 0
+                color:     @model.color
+                hovered:   @model.hovered
+                radius:    @model.radius
+                typeName:  @model.typeName
 
     connectionPosition: => @parent.parent.model.position
 

--- a/src/view/port/sub/InArrow.coffee
+++ b/src/view/port/sub/InArrow.coffee
@@ -35,6 +35,8 @@ export class InArrow extends Subport
             border: @style.port_typeBorder
             color: [@model.color[0], @model.color[1],
                     @model.color[2], @model.hovered]
+        if @changed.connected
+            @updateDef 'port', connected: @model.connected
         if @changed.color
             @updateDef 'port', color: @model.color
 

--- a/src/view/port/sub/OutArrow.coffee
+++ b/src/view/port/sub/OutArrow.coffee
@@ -7,6 +7,7 @@ import {TextContainer} from 'view/Text'
 export class OutArrow extends Subport
     initModel: =>
         angle: 0
+        connected: false
         color: [1, 0, 0]
         hovered: false
         typeName: ''
@@ -24,6 +25,8 @@ export class OutArrow extends Subport
                 [ @style.port_borderColor_h, @style.port_borderColor_s
                 , @style.port_borderColor_l, @style.port_borderColor_a * Number @model.hovered
                 ]
+        if @changed.connected
+            @updateDef 'port', connected: @model.connected
         if @changed.color
             @updateDef 'port', color: @model.color
 

--- a/src/view/port/sub/Self.coffee
+++ b/src/view/port/sub/Self.coffee
@@ -23,6 +23,8 @@ export class Self extends Subport
             color: [@style.text_color_r, @style.text_color_g, @style.text_color_b, @model.hovered]
         if @changed.color
             @updateDef 'port', color: @model.color
+        if @changed.connected
+            @updateDef 'port', connected: @model.connected
 
     adjust: (view) =>
         if @view('typeName')?


### PR DESCRIPTION
If connections overlap over a port, it is important to determine if port is connected or not. This PR adds a frame to not connected ports in the color of the background